### PR TITLE
Fixed Version Comparison.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+##### 1.1.1 fix version comparison
+
 ##### 1.1.0 switched from docker-engine to docker-ce packages
 * dropped support for alpine and debian 7
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,11 +5,11 @@
 
 - name: install docker ce for ubuntu
   include: install-ubuntu.yml
-  when: ansible_distribution == "Ubuntu" and ansible_lsb.major_release >= 16
+  when: ansible_distribution == "Ubuntu" and ansible_lsb.major_release|int >= 16
 
 - name: install docker ce for debian
   include: install-debian.yml
-  when: ansible_distribution == "Debian" and ansible_distribution_major_version >= 8
+  when: ansible_distribution == "Debian" and ansible_distribution_major_version|int >= 8
 
 - name: install docker ce with yum
   include: install-centos.yml


### PR DESCRIPTION
Fixed an error where a playbook will fail because of the comparison of an int (given version) against a string (ansible_lsb.major_release).

Using python 3.6