### PR TITLE
Update package management task syntax

### DIFF
--- a/tasks/install-centos.yml
+++ b/tasks/install-centos.yml
@@ -1,14 +1,13 @@
 ---
 - name: purge old docker packages
   yum:
-    name: "{{ item }}"
+    name:
+      - docker
+      - docker-common
+      - container-selinux
+      - docker-selinux
+      - docker-engine
     state: absent
-  with_items:
-    - docker
-    - docker-common
-    - container-selinux
-    - docker-selinux
-    - docker-engine
 
 - name: install requirements
   yum:

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -1,14 +1,13 @@
 ---
 - name: install packages
   apt:
-    name: "{{ item }}"
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - gnupg2
+      - software-properties-common
     update_cache: yes
     cache_valid_time: "{{ docker_engine_cache_valid_time }}"
-  with_items:
-    - apt-transport-https
-    - ca-certificates
-    - gnupg2
-    - software-properties-common
 
 - name: add docker apt key
   apt_key:

--- a/tasks/install-fedora.yml
+++ b/tasks/install-fedora.yml
@@ -4,14 +4,13 @@
 
 - name: purge old docker packages
   dnf:
-    name: "{{ item }}"
+    name:
+      - docker
+      - docker-common
+      - container-selinux
+      - docker-selinux
+      - docker-engine
     state: absent
-  with_items:
-    - docker
-    - docker-common
-    - container-selinux
-    - docker-selinux
-    - docker-engine
 
 - name: add docker-ce repository
   yum_repository:
@@ -21,15 +20,7 @@
     gpgkey: https://download.docker.com/linux/fedora/gpg
     gpgcheck: yes
     file: docker
-#- name: add docker repository (fedora)
-#   yum_repository:
-#     name: dockerrepo
-#     description: Docker Repository
-#     baseurl: https://yum.dockerproject.org/repo/"{{ docker_engine_release_channel }}"/fedora/$releasever/
-#     gpgkey: https://yum.dockerproject.org/gpg
-#     gpgcheck: yes
-#     file: docker
-#
+
 - name: install docker-ce
   dnf:
     name: docker-ce

--- a/tasks/install-ubuntu.yml
+++ b/tasks/install-ubuntu.yml
@@ -1,13 +1,12 @@
 ---
 - name: install packages
   apt:
-    name: "{{ item }}"
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - software-properties-common
     update_cache: yes
     cache_valid_time: "{{ docker_engine_cache_valid_time }}"
-  with_items:
-    - apt-transport-https
-    - ca-certificates
-    - software-properties-common
 
 - name: add docker apt key
   apt_key:

--- a/tasks/purge-apt.yml
+++ b/tasks/purge-apt.yml
@@ -1,14 +1,13 @@
 ---
 - name: purge old docker packages
   apt:
-    name: "{{ item }}"
+    name:
+      - docker.io
+      - lxc-docker
+      - docker
+      - docker-engine
     state: absent
     purge: yes
-  with_items:
-    - docker.io
-    - lxc-docker
-    - docker
-    - docker-engine
 
 - name: remove old docker-engine apt key
   apt_key:


### PR DESCRIPTION
Loops are no longer needed for package management tasks. Instead, we can just pass a list.

This removes these errors:
```
[DEPRECATION WARNING]: Invoking "dnf" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: "{{ item }}"`, please use `name: ['docker', 'docker-common', 'container-selinux',
'docker-selinux', 'docker-engine']` and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

Thanks for including the tests (they all pass)!